### PR TITLE
Add option to make the invisible leading stars.

### DIFF
--- a/org-bullets.el
+++ b/org-bullets.el
@@ -57,6 +57,18 @@ It can contain any number of symbols, which will be repeated."
   :group 'org-bullets
   :type 'symbol)
 
+(defcustom org-bullets-invisible-leading-stars nil
+  "Invisible leading stars, instead of hidden via colour.
+
+Instead of making leading stars of headings have the same
+colour with background, make them disappear completely.  Useful
+if the theme used or the contents of `org-bullets-bullet-list'
+makes obvious the level of the heading.  Be aware that the
+distance of the bullets from the left edge of the window will be
+identical for all levels."
+  :group 'org-bullets
+  :type 'boolean)
+
 (defvar org-bullets-bullet-map
   '(keymap
     (mouse-1 . org-cycle)
@@ -99,11 +111,15 @@ Should this be undesirable, one can remove them with
                                         (- (match-end 0) 1)
                                         'face
                                         org-bullets-face-name))
-                   (put-text-property (match-beginning 0)
-                                      (- (match-end 0) 2)
-                                      'face (list :foreground
-                                                  (face-attribute
-                                                   'default :background)))
+                   (if org-bullets-invisible-leading-stars
+                      (put-text-property (match-beginning 0)
+                                         (- (match-end 0) 2)
+                                         'invisible t)
+                    (put-text-property (match-beginning 0)
+                                       (- (match-end 0) 2)
+                                       'face (list :foreground
+                                                   (face-attribute
+                                                    'default :background))))
                    (put-text-property (match-beginning 0)
                                       (match-end 0)
                                       'keymap

--- a/org-bullets.el
+++ b/org-bullets.el
@@ -114,7 +114,7 @@ Should this be undesirable, one can remove them with
                    (if org-bullets-invisible-leading-stars
                       (put-text-property (match-beginning 0)
                                          (- (match-end 0) 2)
-                                         'invisible t)
+                                         'display '(space . (:width 0)))
                     (put-text-property (match-beginning 0)
                                        (- (match-end 0) 2)
                                        'face (list :foreground


### PR DESCRIPTION
Add option to make them invisible, not hidden by means of it's colour.
Thus, the end result looks like

```
x Heading level 1
o Heading level 2
> Heading level 3
o Heading level 2
```

instead of

```
x Heading level 1
 o Heading level 2
  > Heading level 3
 o Heading level 2
```

if `org-bullets-invisible-leading-stars` is `t`. Useful if the the
contents of `org-bullets-bullet-list` makes obvious the level of the
heading, and indentation is superfluous.
