### PR TITLE
Changed cl for cl-lib

### DIFF
--- a/org-bullets.el
+++ b/org-bullets.el
@@ -27,7 +27,7 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl))
+(eval-when-compile (require 'cl-lib))
 
 (defgroup org-bullets nil
   "Display bullets as UTF-8 characters"


### PR DESCRIPTION
Removes "package cl is deprecated" warning in emacs 27.1.

For more info see this thread:
https://github.com/kiwanami/emacs-epc/issues/35